### PR TITLE
Bypass on html img conversion from options using base64 img src.

### DIFF
--- a/jquery.googoose.js
+++ b/jquery.googoose.js
@@ -32,6 +32,7 @@
             area: 'div.googoose-wrapper',
             margins: '1.0in',
             zoom: '75',
+            base64 : false, //used for base64 images of type i.e <img src="data:image/jpeg;base64,..." >
             filename: 'Doc1_' + now + '.doc',
             size: '8.5in 11.0in',
             display: 'Print',
@@ -108,7 +109,8 @@
             html = GG.convert_pagebreaks(html);
             html = GG.convert_toc(html);
             html = GG.convert_hdrftr(html);
-            html = GG.convert_imgs(html);
+            if( !options.base64 ) //bypasses the conversion if the img is src base64.
+                html = GG.convert_imgs(html);
 
             return html;
         }
@@ -193,6 +195,7 @@
                 } else if( ab.test( src ) ) {
                     src = t + src; 
                 } else {
+                    //Likley require a warning here for errors to inform user to use base64 bypass option.
                    var p = l.path.replace('/\/[^\/.]+$/', '/' );
                    src = t + p + src;
                 }


### PR DESCRIPTION
In the event that the images are imported as base64 set option as 

base64 : true 

to allow images to export correctly to word.